### PR TITLE
Public API

### DIFF
--- a/src/core/hex.rs
+++ b/src/core/hex.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) A5 contributors
 
-use num_bigint::BigInt;
-use num_traits::Num;
-
-/// Converts a hexadecimal string to a BigInt
+/// Converts a hexadecimal string to a u64
 ///
 /// # Arguments
 ///
@@ -13,23 +10,22 @@ use num_traits::Num;
 ///
 /// # Returns
 ///
-/// A BigInt representing the hexadecimal value
-pub fn hex_to_big_int(hex: &str) -> BigInt {
+/// A u64 representing the hexadecimal value
+pub fn hex_to_u64(hex: &str) -> Result<u64, String> {
     // Remove any "0x" prefix if present
     let hex = hex.trim_start_matches("0x");
-    BigInt::from_str_radix(hex, 16).expect("Invalid hex string")
+    u64::from_str_radix(hex, 16).map_err(|e| format!("Invalid hex string: {}", e))
 }
 
-/// Converts a BigInt to a hexadecimal string
+/// Converts a u64 to a hexadecimal string
 ///
 /// # Arguments
 ///
-/// * `value` - A BigInt to convert
+/// * `value` - A u64 to convert
 ///
 /// # Returns
 ///
 /// A string containing the hexadecimal representation
-pub fn big_int_to_hex(value: &BigInt) -> String {
+pub fn u64_to_hex(value: u64) -> String {
     format!("{value:x}")
 }
-

--- a/src/core/hex.rs
+++ b/src/core/hex.rs
@@ -33,15 +33,3 @@ pub fn big_int_to_hex(value: &BigInt) -> String {
     format!("{value:x}")
 }
 
-/// Converts a u64 to a hexadecimal string
-///
-/// # Arguments
-///
-/// * `value` - A u64 to convert
-///
-/// # Returns
-///
-/// A string containing the hexadecimal representation
-pub fn u64_to_hex(value: u64) -> String {
-    format!("{value:x}")
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,16 @@ pub mod utils;
 
 #[cfg(test)]
 mod test;
+
+// PUBLIC API
+// Indexing
+pub use core::cell::{cell_to_boundary, cell_to_lonlat, lonlat_to_cell};
+pub use core::hex::{hex_to_u64, u64_to_hex};
+
+// Hierarchy
+pub use core::serialization::{cell_to_parent, cell_to_children, get_resolution, get_res0_cells};
+pub use core::cell_info::{get_num_cells, cell_area};
+
+// Types
+pub use coordinate_systems::{Degrees, Radians, LonLat};
+pub use core::utils::A5Cell;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub mod utils;
 // PUBLIC API
 // Indexing
 pub use core::cell::{cell_to_boundary, cell_to_lonlat, lonlat_to_cell};
-pub use core::hex::{u64_to_hex, hex_to_u64};
+pub use core::hex::{hex_to_u64, u64_to_hex};
 
 // Hierarchy
 pub use core::cell_info::{cell_area, get_num_cells};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub mod utils;
 // PUBLIC API
 // Indexing
 pub use core::cell::{cell_to_boundary, cell_to_lonlat, lonlat_to_cell};
-pub use core::hex::{hex_to_big_int, big_int_to_hex, u64_to_hex};
+pub use core::hex::{hex_to_big_int, big_int_to_hex};
 
 // Hierarchy
 pub use core::serialization::{cell_to_parent, cell_to_children, get_resolution, get_res0_cells};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,16 +14,15 @@ pub mod projections;
 #[cfg_attr(not(test), allow(unused))]
 pub mod utils;
 
-
 // PUBLIC API
 // Indexing
 pub use core::cell::{cell_to_boundary, cell_to_lonlat, lonlat_to_cell};
-pub use core::hex::{hex_to_big_int, big_int_to_hex};
+pub use core::hex::{u64_to_hex, hex_to_u64};
 
 // Hierarchy
-pub use core::serialization::{cell_to_parent, cell_to_children, get_resolution, get_res0_cells};
-pub use core::cell_info::{get_num_cells, cell_area};
+pub use core::cell_info::{cell_area, get_num_cells};
+pub use core::serialization::{cell_to_children, cell_to_parent, get_res0_cells, get_resolution};
 
 // Types
-pub use coordinate_systems::{Degrees, Radians, LonLat};
+pub use coordinate_systems::{Degrees, LonLat, Radians};
 pub use core::utils::A5Cell;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,19 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) A5 contributors
 
+// Internal modules - public only for testing
+#[cfg_attr(not(test), allow(unused))]
 pub mod coordinate_systems;
+#[cfg_attr(not(test), allow(unused))]
 pub mod core;
+#[cfg_attr(not(test), allow(unused))]
 pub mod geometry;
+#[cfg_attr(not(test), allow(unused))]
 pub mod projections;
+#[cfg_attr(not(test), allow(unused))]
 pub mod utils;
 
-#[cfg(test)]
-mod test;
 
 // PUBLIC API
 // Indexing
 pub use core::cell::{cell_to_boundary, cell_to_lonlat, lonlat_to_cell};
-pub use core::hex::{hex_to_u64, u64_to_hex};
+pub use core::hex::{hex_to_big_int, big_int_to_hex, u64_to_hex};
 
 // Hierarchy
 pub use core::serialization::{cell_to_parent, cell_to_children, get_resolution, get_res0_cells};

--- a/tests/cell.rs
+++ b/tests/cell.rs
@@ -2,7 +2,7 @@ use a5::coordinate_systems::LonLat;
 use a5::core::cell::{
     a5cell_contains_point, cell_to_boundary, lonlat_to_cell, CellToBoundaryOptions,
 };
-use a5::core::hex::hex_to_big_int;
+use a5::core::hex::hex_to_u64;
 use a5::core::serialization::{deserialize, MAX_RESOLUTION};
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -40,11 +40,7 @@ fn test_antimeridian_cell_longitude_span() {
 
     for cell_id_hex in &antimeridian_cells {
         for &segment in &segments {
-            let cell_id = hex_to_big_int(cell_id_hex);
-            let cell_id_u64 = cell_id
-                .to_string()
-                .parse::<u64>()
-                .expect("Failed to convert to u64");
+            let cell_id_u64 = hex_to_u64(cell_id_hex).expect("Failed to parse hex");
 
             let options = CellToBoundaryOptions {
                 closed_ring: true,
@@ -67,11 +63,7 @@ fn test_antimeridian_cell_longitude_span() {
         }
 
         // Test with 'auto' segments (None option)
-        let cell_id = hex_to_big_int(cell_id_hex);
-        let cell_id_u64 = cell_id
-            .to_string()
-            .parse::<u64>()
-            .expect("Failed to convert to u64");
+        let cell_id_u64 = hex_to_u64(cell_id_hex).expect("Failed to parse hex");
 
         let boundary = cell_to_boundary(cell_id_u64, None).expect("Failed to get boundary");
 

--- a/tests/hex.rs
+++ b/tests/hex.rs
@@ -1,4 +1,4 @@
-use a5::core::hex::{u64_to_hex, hex_to_u64};
+use a5::core::hex::{hex_to_u64, u64_to_hex};
 
 #[test]
 fn test_hex_conversion() {

--- a/tests/hex.rs
+++ b/tests/hex.rs
@@ -1,25 +1,25 @@
-use a5::core::hex::{big_int_to_hex, hex_to_big_int};
+use a5::core::hex::{u64_to_hex, hex_to_u64};
 
 #[test]
 fn test_hex_conversion() {
     let hex = "1a2b3c4d";
-    let big_int = hex_to_big_int(hex);
-    let result = big_int_to_hex(&big_int);
+    let u64_val = hex_to_u64(hex).unwrap();
+    let result = u64_to_hex(u64_val);
     assert_eq!(result, hex);
 }
 
 #[test]
 fn test_hex_conversion_with_zero() {
     let hex = "0";
-    let big_int = hex_to_big_int(hex);
-    let result = big_int_to_hex(&big_int);
+    let u64_val = hex_to_u64(hex).unwrap();
+    let result = u64_to_hex(u64_val);
     assert_eq!(result, hex);
 }
 
 #[test]
 fn test_hex_conversion_with_large_number() {
     let hex = "ffffffffffffffff";
-    let big_int = hex_to_big_int(hex);
-    let result = big_int_to_hex(&big_int);
+    let u64_val = hex_to_u64(hex).unwrap();
+    let result = u64_to_hex(u64_val);
     assert_eq!(result, hex);
 }


### PR DESCRIPTION
<!-- For all the PRs -->
#### Change List
- Avoid `use a5::core::{cell::cell_to_boundary, serialization::cell_to_children, hex::u64_to_hex};` with re-exports of public API
- Rename `hex_to_big_int` to `hex_to_u64`
